### PR TITLE
Make LeoECS nuget packaging friendly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,20 @@
 Library
 obj
 Temp
+
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+[Aa][Rr][Mm]/
+[Aa][Rr][Mm]64/
+bld/
+[Bb]in/
+[Oo]bj/
+[Ll]og/
+
+# Visual Studio 2015/2017 cache/options directory
+.vs/

--- a/Leopotam.Ecs.csproj
+++ b/Leopotam.Ecs.csproj
@@ -1,6 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <DefineConstants>NET_STANDARD_2_0</DefineConstants>
+    <Version>1.0.0</Version>
+    <Authors>Leopotam</Authors>
+    <Product>LeoEcs</Product>
+    <Description>LeoECS is a fast Entity Component System (ECS) Framework powered by C#</Description>
+    <PackageProjectUrl>https://github.com/Leopotam/ecs</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Leopotam/ecs.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <IncludeSource>true</IncludeSource>
+    <IncludeSymbols>true</IncludeSymbols>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This is to make LeoECS friendly to packaging with Nuget, very appreciated by people outside of the Unity sphere. It does however require another version naming schema.