### PR TITLE
Make LeoECS nuget packaging friendly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,20 @@
 Library
 obj
 Temp
+
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+[Aa][Rr][Mm]/
+[Aa][Rr][Mm]64/
+bld/
+[Bb]in/
+[Oo]bj/
+[Ll]og/
+
+# Visual Studio 2015/2017 cache/options directory
+.vs/

--- a/Leopotam.Ecs.csproj
+++ b/Leopotam.Ecs.csproj
@@ -1,6 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <DefineConstants>NET_STANDARD_2_0</DefineConstants>
+    <Version>1.0.0</Version>
+    <Authors>Leopotam</Authors>
+    <Product>LeoEcs</Product>
+    <Description>LeoECS is a fast Entity Component System (ECS) Framework powered by C#</Description>
+    <PackageProjectUrl>https://github.com/Leopotam/ecs</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Leopotam/ecs.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <IncludeSource>true</IncludeSource>
+    <IncludeSymbols>true</IncludeSymbols>
   </PropertyGroup>
 </Project>

--- a/Leopotam.Ecs.csproj
+++ b/Leopotam.Ecs.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
-    <DefineConstants>NET_STANDARD_2_0</DefineConstants>
+    <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
     <Version>2019.2.22</Version>
     <Authors>Leopotam</Authors>
     <Product>LeoEcs</Product>

--- a/Leopotam.Ecs.csproj
+++ b/Leopotam.Ecs.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <DefineConstants>NET_STANDARD_2_0</DefineConstants>
-    <Version>1.0.0</Version>
+    <Version>2019.2.22</Version>
     <Authors>Leopotam</Authors>
     <Product>LeoEcs</Product>
     <Description>LeoECS is a fast Entity Component System (ECS) Framework powered by C#</Description>

--- a/src/EcsComponentMask.cs
+++ b/src/EcsComponentMask.cs
@@ -48,7 +48,7 @@ namespace Leopotam.Ecs {
         }
 #endif
 
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public void SetBit (int bitId, bool state) {
@@ -73,7 +73,7 @@ namespace Leopotam.Ecs {
             }
         }
 
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public bool GetBit (int bitId) {
@@ -86,7 +86,7 @@ namespace Leopotam.Ecs {
             return i != -1;
         }
 
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public void CopyFrom (EcsComponentMask mask) {
@@ -97,7 +97,7 @@ namespace Leopotam.Ecs {
             Array.Copy (mask.Bits, 0, Bits, 0, BitsCount);
         }
 
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public bool IsCompatible (EcsFilter filter) {
@@ -123,7 +123,7 @@ namespace Leopotam.Ecs {
             return false;
         }
 
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public bool IsIntersects (EcsComponentMask mask) {

--- a/src/EcsComponentPool.cs
+++ b/src/EcsComponentPool.cs
@@ -93,7 +93,7 @@ namespace Leopotam.Ecs {
 #endif
         }
 
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public int RequestNewId () {
@@ -110,7 +110,7 @@ namespace Leopotam.Ecs {
             return id;
         }
 
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public void RecycleById (int id) {
@@ -134,21 +134,21 @@ namespace Leopotam.Ecs {
             ReservedItems[ReservedItemsCount++] = id;
         }
 
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public object GetExistItemById (int idx) {
             return Items[idx];
         }
 
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public int GetComponentTypeIndex () {
             return TypeIndex;
         }
 
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public bool IsOneFrameComponent () {

--- a/src/EcsFilter.cs
+++ b/src/EcsFilter.cs
@@ -35,7 +35,7 @@ namespace Leopotam.Ecs {
             AddComponentPool (EcsComponentPool<Inc1>.Instance);
         }
 
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public override void RaiseOnAddEvent (int entity) {
@@ -53,7 +53,7 @@ namespace Leopotam.Ecs {
                 _listeners[j].OnEntityAdded (entity);
             }
         }
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public override void RaiseOnRemoveEvent (int entity) {
@@ -119,7 +119,7 @@ namespace Leopotam.Ecs {
             AddComponentPool (EcsComponentPool<Inc2>.Instance);
             ValidateMasks (2, 0);
         }
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public override void RaiseOnAddEvent (int entity) {
@@ -143,7 +143,7 @@ namespace Leopotam.Ecs {
                 _listeners[j].OnEntityAdded (entity);
             }
         }
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public override void RaiseOnRemoveEvent (int entity) {
@@ -218,7 +218,7 @@ namespace Leopotam.Ecs {
             AddComponentPool (EcsComponentPool<Inc3>.Instance);
             ValidateMasks (3, 0);
         }
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public override void RaiseOnAddEvent (int entity) {
@@ -248,7 +248,7 @@ namespace Leopotam.Ecs {
                 _listeners[j].OnEntityAdded (entity);
             }
         }
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public override void RaiseOnRemoveEvent (int entity) {
@@ -332,7 +332,7 @@ namespace Leopotam.Ecs {
             AddComponentPool (EcsComponentPool<Inc4>.Instance);
             ValidateMasks (4, 0);
         }
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public override void RaiseOnAddEvent (int entity) {
@@ -368,7 +368,7 @@ namespace Leopotam.Ecs {
                 _listeners[j].OnEntityAdded (entity);
             }
         }
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public override void RaiseOnRemoveEvent (int entity) {
@@ -480,14 +480,14 @@ namespace Leopotam.Ecs {
         /// </summary>
         public int[] Entities = new int[MinSize];
 
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public Enumerator GetEnumerator () {
             return new Enumerator (_entitiesCount);
         }
 
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         /// <summary>
@@ -509,7 +509,7 @@ namespace Leopotam.Ecs {
             readonly int _count;
             int _idx;
 
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
             [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
             internal Enumerator (int entitiesCount) {
@@ -518,7 +518,7 @@ namespace Leopotam.Ecs {
             }
 
             public int Current {
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
                 [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
                 get { return _idx; }
@@ -526,26 +526,26 @@ namespace Leopotam.Ecs {
 
             object System.Collections.IEnumerator.Current { get { return null; } }
 
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
             [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
             public void Dispose () { }
 
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
             [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
             public bool MoveNext () {
                 return ++_idx < _count;
             }
 
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
             [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
             public void Reset () {
                 _idx = -1;
             }
 
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
             [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
             public int GetCount () {

--- a/src/EcsHelpers.cs
+++ b/src/EcsHelpers.cs
@@ -11,7 +11,7 @@ namespace Leopotam.Ecs.Internals {
     /// Internal helpers.
     /// </summary>
     public static class EcsHelpers {
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int GetPowerOfTwoSize (int n) {

--- a/src/EcsWorld.cs
+++ b/src/EcsWorld.cs
@@ -8,7 +8,7 @@ using System;
 using System.Collections.Generic;
 using Leopotam.Ecs.Internals;
 
-#if !NET_4_6 && !NET_STANDARD_2_0
+#if !NET46 && !NETSTANDARD2_0
 #warning [Leopotam.Ecs] .Net Framework v3.5 support deprecated and will be removed in next release.
 #endif
 
@@ -295,7 +295,7 @@ namespace Leopotam.Ecs {
         /// </summary>
         /// <param name="entity">Entity.</param>
         /// <param name="isNew">Is component was added in this call?</param>
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public T EnsureComponent<T> (int entity, out bool isNew) where T : class, new () {
@@ -346,7 +346,7 @@ namespace Leopotam.Ecs {
         /// Adds component to entity. Will throw exception if component already exists.
         /// </summary>
         /// <param name="entity">Entity.</param>
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public T AddComponent<T> (int entity) where T : class, new () {
@@ -397,7 +397,7 @@ namespace Leopotam.Ecs {
         /// </summary>
         /// <param name="entity">Entity.</param>
         /// <param name="noerror">Suppress error if component not exists (DEBUG mode only).</param>
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public void RemoveComponent<T> (int entity, bool noError = false) where T : class, new () {
@@ -426,7 +426,7 @@ namespace Leopotam.Ecs {
         /// Gets component on entity.
         /// </summary>
         /// <param name="entity">Entity.</param>
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public T GetComponent<T> (int entity) where T : class, new () {
@@ -470,7 +470,7 @@ namespace Leopotam.Ecs {
         /// Returns true if entity exists.
         /// </summary>
         /// <param name="entity">Entity.</param>
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public bool IsEntityExists (int entity) {
@@ -592,7 +592,7 @@ namespace Leopotam.Ecs {
         /// <summary>
         /// Gets filter with specific include / exclude masks.
         /// </summary>
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public T GetFilter<T> () where T : EcsFilter {
@@ -603,7 +603,7 @@ namespace Leopotam.Ecs {
         /// Gets filter with specific include / exclude masks.
         /// </summary>
         /// <param name="filterType">Type of filter.</param>
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public EcsFilter GetFilter (Type filterType) {
@@ -683,7 +683,7 @@ namespace Leopotam.Ecs {
         /// <summary>
         /// Create entity with support of re-using reserved instances.
         /// </summary>
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         protected int CreateEntityInternal () {
@@ -713,7 +713,7 @@ namespace Leopotam.Ecs {
             return entity;
         }
 
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         protected void AddDelayedUpdate (DelayedUpdate.Op type, int entity, IEcsComponentPool component, int componentId) {
@@ -728,7 +728,7 @@ namespace Leopotam.Ecs {
         /// </summary>
         /// <param name="entity">Entity Id.</param>
         /// <param name="entityData">EcsEntity instance.</param>
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         protected void ReserveEntity (int entity, EcsEntityInternal entityData) {
@@ -755,7 +755,7 @@ namespace Leopotam.Ecs {
         /// <param name="entity">Entity.</param>
         /// <param name="oldMask">Old component state.</param>
         /// <param name="newMask">New component state.</param>
-#if NET_4_6 || NET_STANDARD_2_0
+#if NET46 || NETSTANDARD2_0
         [System.Runtime.CompilerServices.MethodImpl (System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         protected void UpdateFilters (int entity, EcsComponentMask oldMask, EcsComponentMask newMask) {


### PR DESCRIPTION
This is to make LeoECS friendly to packaging with Nuget, very appreciated by people outside of the Unity sphere.

Summary of changes:
* Change to [standardized targetframework](https://docs.microsoft.com/en-us/dotnet/standard/frameworks) pragma defines. This means that the nuget package will resolve your pragma automatically as it will compile one DLL for each target framework. It also means you never need to define constants manually.
* Change targetframework to 4.6, which seems like what you wish to target based on pragma? A bit confused on this actually so please give feedback.
* Package information