### PR TITLE
* EcsGrowList: capacity validation added.

### DIFF
--- a/src/EcsHelpers.cs
+++ b/src/EcsHelpers.cs
@@ -18,6 +18,9 @@ namespace Leopotam.Ecs {
 
         [MethodImpl (MethodImplOptions.AggressiveInlining)]
         public EcsGrowList (int capacity) {
+#if DEBUG
+            if (capacity <= 0) { throw new Exception ("Capacity should be greater than zero."); }
+#endif
             Items = new T[capacity];
             Count = 0;
         }


### PR DESCRIPTION
`Add` method fails to expand list if its capacity is 0. DEBUG-only validation added to shoot it in right place